### PR TITLE
pass options to multiGlob

### DIFF
--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -244,10 +244,13 @@ var HTML2JS = {
    * @return {String}
    */
   generate: function (_HTML2JS, srcDir, destDir) {
+    var options = _HTML2JS.options;
+    if (typeof options.cwd === 'undefined' || options.cwd !== srcDir) {
+      options.cwd = srcDir;
+    }
     var destPathDir    = path.join(destDir, path.dirname(_HTML2JS.outputFile)),
         destPathFile   = path.join(destDir, _HTML2JS.outputFile),
-        files          = multiGlob(_HTML2JS.inputFiles, {cwd: srcDir}),
-        options        = _HTML2JS.options,
+        files          = multiGlob(_HTML2JS.inputFiles, options),
         targetType     = destPathFile.split('.').pop(),
         isSingleModule = function () {
           return options.module && options.singleModule === true;


### PR DESCRIPTION
Currently, any expected options passed through `html2js` will not make it to `multiGlob`.
